### PR TITLE
v0.0.9: Add shipping cost

### DIFF
--- a/app/controllers/spree/paypal_checkout_controller.rb
+++ b/app/controllers/spree/paypal_checkout_controller.rb
@@ -93,6 +93,10 @@ module Spree
                 item_total: {
                   currency_code: current_order.currency,
                   value: items.sum{|r| (r[:unit_amount][:value] * r[:quantity]) }
+                },
+                shipping: {
+                  currency_code: current_order.currency,
+                  value: current_order.shipments.sum(:cost)
                 }
               }
             },


### PR DESCRIPTION
**Issue**
Shipping Cost was not getting included while creating the PayPal Order object.