### PR TITLE
v0.1.4: Rescued condition for other payment methods

### DIFF
--- a/app/models/spree/log_entry_decorator.rb
+++ b/app/models/spree/log_entry_decorator.rb
@@ -1,7 +1,7 @@
 module Spree
   module LogEntryDecorator
     def parsed_details
-      @details ||= YAML.safe_load(details, [ActiveMerchant::Billing::Response, Net::HTTPCreated, URI::HTTPS, URI::RFC3986_Parser, Symbol, Regexp, Object])
+      @details ||= YAML.safe_load(details, [ActiveMerchant::Billing::Response, Net::HTTPCreated, URI::HTTPS, URI::RFC3986_Parser, Symbol, Regexp, Object, ActiveMerchant::Billing::MultiResponse]) rescue nil
     end
 
     def success_parsed_details?

--- a/app/views/spree/admin/log_entries/index.html.erb
+++ b/app/views/spree/admin/log_entries/index.html.erb
@@ -21,7 +21,7 @@
       </tr>
     </thead>
     <tbody>
-      <%= render "spree/admin/log_entries/#{@payment.payment_method.method_type.gsub(' ', '').underscore}", entry: entry %>
+      <%= render "spree/admin/log_entries/#{@payment.payment_method.method_type.gsub(' ', '').underscore}", entry: entry rescue '' %>
     </tbody>
   <% end %>
 </table>


### PR DESCRIPTION
### Summary

**Issue**:
Getting an exception for Stripe Log Entries view
ActionView::Template::Error (Tried to load unspecified class: ActiveMerchant::Billing::MultiResponse)

**Fix**
Rescued condition for different ActiveMerchant::Billing::MultiResponse classes.
By default, Spree core doesn't provide the ActiveMerchant::Billing::MultiResponse class to get loaded. But we added to resolve the few Payment Methods responses (like Stripe).
